### PR TITLE
Use parameters after script name as arguments to script on VM

### DIFF
--- a/buildbot
+++ b/buildbot
@@ -5,6 +5,7 @@ from pathlib import Path
 from subprocess import run, PIPE
 from contextlib import contextmanager
 from argparse import ArgumentParser
+from pipes import quote
 
 SHARED = Path(__file__).resolve().parent / 'shared'
 
@@ -23,15 +24,13 @@ def instance():
         echo_run(['kitchen', 'destroy', vm])
 
 def run_buildbot(*args):
-    parser = ArgumentParser()
-    parser.add_argument('script')
-    options = parser.parse_args(args)
-
-    script = Path(options.script).resolve().relative_to(SHARED)
+    script = Path(args[0]).resolve().relative_to(SHARED)
 
     with instance() as vm:
         vm_script = Path('/mnt/shared') / script
         cmd = 'sudo {}'.format(str(vm_script))
+        if len(args) > 1:
+            cmd += ' ' + ' '.join(quote(arg) for arg in args[1:])
         echo_run(['kitchen', 'exec', vm, '-c', cmd])
 
 def login():


### PR DESCRIPTION
I'm thinking the new convert-image.sh script will need command line parameters to specify the kind of image wanted, and buildbot would need to pass them via the run command. With ArgumentParser I'm not sure how to pass all the parameters after the script name to the script, so I did this: https://github.com/dreamlayers/buildbot/commit/574d78f88399695db44106930c18c85c3418ebfa Not sure if this change is wanted because I removed ArgumentParser from the run command, but it was unnecessary there anyways.