### PR TITLE
Optimize

### DIFF
--- a/factory.py
+++ b/factory.py
@@ -221,7 +221,7 @@ class VM:
             '-daemonize',
             '-display', 'none',
             '-chardev', 'socket,id=mon-qmp,path=vm.qmp,server,nowait',
-            '-mon', 'chardev=mon-qmp,mode=control,default',
+            '-mon', 'chardev=mon-qmp,mode=control',
             '-serial', 'mon:unix:path=vm.mon,server,nowait',
             '-m', str(self.options.memory),
             '-enable-kvm',

--- a/factory.py
+++ b/factory.py
@@ -525,6 +525,7 @@ password: ubuntu
 chpasswd: { expire: False }
 ssh_pwauth: True
 runcmd:
+  - "echo '127.0.1.1 ubuntu' >> /etc/hosts"
   - "touch /etc/cloud/cloud-init.disabled"
   - "systemctl disable apt-daily.service"
   - "systemctl disable apt-daily.timer"


### PR DESCRIPTION
* Previously, a 2GB swapfile was created during prepare-cloud-image. Now a 2GB qcow disk is created when the VM boots. This doesn't greatly increase boot time, and reduces the cloud image size from 2980MB to 931MB. (Hmm, why are we so much bigger than an ubuntu cloud image, which is 280MB?)
* Add a line to `/etc/hosts` so that sudo doesn't complain any more
* Remove a deprecated qemu argument
