### PR TITLE
handle SIGTERM and shut down gracefully

### DIFF
--- a/factory
+++ b/factory
@@ -3,4 +3,5 @@
 import sys
 import factory
 
+factory.handle_sigterm()
 factory.main(sys.argv[1:])

--- a/factory.py
+++ b/factory.py
@@ -704,8 +704,11 @@ def set_up_logging(quiet, verbose):
     logging.basicConfig(level=log_level, format='%(message)s')
 
 
-def main(argv):
+def handle_sigterm():
     signal.signal(signal.SIGTERM, lambda *args: sys.exit(1))
+
+
+def main(argv):
     arch = get_arch()
     if arch in DEFAULTS.keys():
         default_platform = DEFAULTS[arch]

--- a/factory.py
+++ b/factory.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from argparse import ArgumentParser, REMAINDER
 import shlex
 import logging
+import signal
 
 """
 reference:
@@ -704,6 +705,7 @@ def set_up_logging(quiet, verbose):
 
 
 def main(argv):
+    signal.signal(signal.SIGTERM, lambda *args: sys.exit(1))
     arch = get_arch()
     if arch in DEFAULTS.keys():
         default_platform = DEFAULTS[arch]

--- a/factory.py
+++ b/factory.py
@@ -705,7 +705,11 @@ def set_up_logging(quiet, verbose):
 
 
 def handle_sigterm():
-    signal.signal(signal.SIGTERM, lambda *args: sys.exit(1))
+    def handler(*args):
+        logger.debug("Caught SIGTERM, shutting down")
+        sys.exit(1)
+
+    signal.signal(signal.SIGTERM, handler)
 
 
 def main(argv):


### PR DESCRIPTION
This is useful when running with supervisor, which sends SIGTERM to a process so it can gracefully shut down. By default Python ignores that signal and the kernel unceremoniously kills it.